### PR TITLE
chore: 명세서 동기화 & 테스트용 API 추가

### DIFF
--- a/prisma/seed-extra.js
+++ b/prisma/seed-extra.js
@@ -143,6 +143,82 @@ async function main() {
   }
 
   // ============================
+  // 2-2) expert_answers 보강 (morePosts용 2개 보장)
+  // ============================
+  const existingAnswers = await prisma.expert_answers.findMany({
+    select: {
+      answer_id: true,
+      symptom_id: true,
+      symptoms: { select: { pain_area_id: true } },
+    },
+  });
+
+  const answersBySymptom = new Map();
+  const answersByPainArea = new Map();
+
+  for (const answer of existingAnswers) {
+    const symptomKey = Number(answer.symptom_id);
+    answersBySymptom.set(symptomKey, (answersBySymptom.get(symptomKey) || 0) + 1);
+
+    const painAreaKey = Number(answer.symptoms?.pain_area_id);
+    if (!Number.isNaN(painAreaKey)) {
+      answersByPainArea.set(painAreaKey, (answersByPainArea.get(painAreaKey) || 0) + 1);
+    }
+  }
+
+  const plannedPainAreaCounts = new Map(answersByPainArea);
+  const extraAnswers = [];
+  let extraIndex = 1;
+
+  for (const symptom of symptoms) {
+    const symptomKey = Number(symptom.symptom_id);
+    if ((answersBySymptom.get(symptomKey) || 0) > 0) continue;
+
+    const painAreaKey = Number(symptom.pain_area_id);
+    const areaName = painAreaMap[painAreaKey] || '통증 부위';
+
+    extraAnswers.push({
+      symptom_id: symptom.symptom_id,
+      summary: `${areaName} ${symptom.name} 증상은 다양한 원인으로 인해 발생할 수 있습니다.`,
+      full_content: `${areaName} ${symptom.name} 증상에 대한 전문의 진료 기록입니다.\n\n원인:\n- 잘못된 자세 유지\n- 근육 피로\n- 염증성 질환\n\n치료 방법:\n1. 물리 치료\n2. 스트레칭 운동\n3. 약물 치료\n4. 생활 습관 개선\n\n예방:\n- 정기적인 운동\n- 올바른 자세 유지\n- 스트레스 관리\n- 충분한 휴식`,
+      source_url: `https://example.com/treatments/extra-${extraIndex++}`,
+    });
+
+    plannedPainAreaCounts.set(
+      painAreaKey,
+      (plannedPainAreaCounts.get(painAreaKey) || 0) + 1
+    );
+  }
+
+  for (const painArea of painAreas) {
+    const painAreaKey = Number(painArea.pain_area_id);
+    let currentCount = plannedPainAreaCounts.get(painAreaKey) || 0;
+    const pool = symptomsByPainArea[painAreaKey] || [];
+
+    let poolIndex = 0;
+    while (currentCount < 3 && pool.length > 0) {
+      const symptom = pool[poolIndex % pool.length];
+      extraAnswers.push({
+        symptom_id: symptom.symptom_id,
+        summary: `${painArea.name} ${symptom.name} 증상은 다양한 원인으로 인해 발생할 수 있습니다.`,
+        full_content: `${painArea.name} ${symptom.name} 증상에 대한 전문의 진료 기록입니다.\n\n원인:\n- 잘못된 자세 유지\n- 근육 피로\n- 염증성 질환\n\n치료 방법:\n1. 물리 치료\n2. 스트레칭 운동\n3. 약물 치료\n4. 생활 습관 개선\n\n예방:\n- 정기적인 운동\n- 올바른 자세 유지\n- 스트레스 관리\n- 충분한 휴식`,
+        source_url: `https://example.com/treatments/extra-${extraIndex++}`,
+      });
+      currentCount += 1;
+      poolIndex += 1;
+    }
+
+    plannedPainAreaCounts.set(painAreaKey, currentCount);
+  }
+
+  if (extraAnswers.length > 0) {
+    await prisma.expert_answers.createMany({ data: extraAnswers });
+    console.log(`expert_answers 추가 ${extraAnswers.length}건 삽입 완료`);
+  } else {
+    console.log('expert_answers 충분히 존재, 보강 건너뜀');
+  }
+
+  // ============================
   // 3) Seed User 증상 보강 (어깨 3개 모두)
   // ============================
   const seedUser = await prisma.users.findFirst({ orderBy: { user_id: 'asc' } });

--- a/src/controllers/home.controller.js
+++ b/src/controllers/home.controller.js
@@ -8,6 +8,7 @@ class HomeController {
     this.getHome = this.getHome.bind(this);
     this.getDoctorAnswerSummary = this.getDoctorAnswerSummary.bind(this);
     this.getDoctorAnswerDetail = this.getDoctorAnswerDetail.bind(this);
+    this.getAllAnswerIds = this.getAllAnswerIds.bind(this);
   }
 
   // 홈 전체 불러오기
@@ -42,6 +43,16 @@ class HomeController {
       const result = await this.service.getDoctorAnswerDetail(answerId, userId);
       
       return sendSuccess(res, result, '전문의 답변 조회 성공');
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  // 전문의 답변 ID 전체 조회 (테스트용)
+  async getAllAnswerIds(req, res, next) {
+    try {
+      const answers = await this.service.getAllAnswerIds();
+      return sendSuccess(res, { answers }, '전문의 답변 ID 조회 성공');
     } catch (err) {
       next(err);
     }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -666,7 +666,30 @@ paths:
                               nullable: true
                               example: "약 10분 소요"
 
-  /homes/expert-summary/{answerId}:
+  /expert-answers/ids:
+    get:
+      tags:
+        - Home
+      summary: 전문의 답변 ID 목록 조회
+      description: 테스트를 위한 전문의 답변 ID와 통증 부위 정보를 조회합니다.
+      responses:
+        "200":
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: "전문의 답변 ID 조회 성공"
+                  data:
+                    $ref: "#/components/schemas/ExpertAnswerIdList"
+
+  /expert-answers/{answerId}/summary:
     get:
       tags:
         - Home
@@ -727,7 +750,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /homes/expert-answers/{answerId}:
+  /expert-answers/{answerId}:
     get:
       tags:
         - Home
@@ -1203,6 +1226,27 @@ components:
         description:
           type: string
           example: "영상 설명..."
+
+    ExpertAnswerIdList:
+      type: object
+      properties:
+        answers:
+          type: array
+          items:
+            type: object
+            properties:
+              answerId:
+                type: integer
+                example: 1
+              symptomId:
+                type: integer
+                example: 10
+              painAreaId:
+                type: integer
+                example: 1
+              painAreaName:
+                type: string
+                example: "어깨"
 
     SuccessResponse:
       type: object

--- a/src/repositories/home.repository.js
+++ b/src/repositories/home.repository.js
@@ -111,6 +111,24 @@ class HomeRepository {
       formattedGuides.push({ guideId: null, title: null, badges: [], description: null, imageUrl: null, type: null, duration: null });
     }
 
+    const mappedMorePosts = morePosts.map(post => ({
+      answerId: Number(post.answer_id),
+      painAreaId: Number(post.symptoms.pain_area_id),
+      symptomId: Number(post.symptom_id),
+      title: `${post.symptoms?.name} 전문의 소견`,
+      imageUrl: null
+    }));
+
+    while (mappedMorePosts.length < 2) {
+      mappedMorePosts.push({
+        answerId: null,
+        painAreaId: null,
+        symptomId: null,
+        title: null,
+        imageUrl: null
+      });
+    }
+
     return {
       painAreaId: Number(primaryPainArea.pain_area_id),
       painAreaName: primaryPainArea.name,
@@ -245,14 +263,30 @@ class HomeRepository {
       imageUrl: null, // expert_answers에 imageUrl 필드가 없으므로 null
       sourceUrl: answer.source_url,
       updatedAt: answer.updated_at,
-      morePosts: morePosts.map(post => ({
-        answerId: Number(post.answer_id),
-        painAreaId: Number(post.symptoms.pain_area_id),
-        symptomId: Number(post.symptom_id),
-        title: `${post.symptoms?.name} 전문의 소견`,
-        imageUrl: null
-      }))
+      morePosts: mappedMorePosts
     };
+  }
+
+  // 전문의 답변 ID 전체 조회 (테스트용)
+  async getAllExpertAnswerIds() {
+    const answers = await this.client.expert_answers.findMany({
+      select: {
+        answer_id: true,
+        symptoms: {
+          select: {
+            name: true,
+            pain_areas: { select: { name: true } }
+          }
+        }
+      },
+      orderBy: { answer_id: 'asc' }
+    });
+
+    return answers.map(answer => ({
+      answerId: Number(answer.answer_id),
+      painAreaName: answer.symptoms.pain_areas?.name ?? null,
+      symptomName: answer.symptoms?.name ?? null
+    }));
   }
 }
 

--- a/src/routes/expertAnswer.routes.js
+++ b/src/routes/expertAnswer.routes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import HomeController from "../controllers/home.controller.js";
+import { authenticate } from "../middleware/auth.middleware.js";
+
+const router = express.Router();
+const controller = new HomeController();
+
+router.get("/ids", controller.getAllAnswerIds);
+router.get("/:answerId/summary", authenticate, controller.getDoctorAnswerSummary);
+router.get("/:answerId", authenticate, controller.getDoctorAnswerDetail);
+
+export default router;

--- a/src/routes/homes.routes.js
+++ b/src/routes/homes.routes.js
@@ -7,7 +7,5 @@ const controller = new HomeController();
 
 // 인증 필요한 라우트
 router.get('/', authenticate, controller.getHome);
-router.get('/expert-summary/:answerId', authenticate, controller.getDoctorAnswerSummary);
-router.get('/expert-answers/:answerId', authenticate, controller.getDoctorAnswerDetail);
 
 export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,6 +5,7 @@ import hospitalRoutes from './hospital.routes.js';
 import painAreaRoutes from './painArea.routes.js';
 import adminRoutes from './admin.routes.js';
 import homesRoutes from './homes.routes.js';
+import expertAnswerRoutes from './expertAnswer.routes.js';
 import lifestyleGuideRoutes from './lifestyleGuide.routes.js';
 import agreementRoutes from './agreement.routes.js';
 import temporaryGuideRoutes from './temporaryGuide.routes.js';
@@ -13,6 +14,7 @@ const router = express.Router();
 
 router.use('/users', userRoutes);
 router.use('/homes', homesRoutes);
+router.use('/expert-answers', expertAnswerRoutes);
 router.use('/hospital', hospitalRoutes);
 router.use('/pain-areas', painAreaRoutes);
 router.use('/admin', adminRoutes);

--- a/src/services/home.service.js
+++ b/src/services/home.service.js
@@ -44,6 +44,11 @@ class HomeService {
 
     return answer;
   }
+
+  // 전문의 답변 ID 전체 조회 (테스트용)
+  async getAllAnswerIds() {
+    return this.repository.getAllExpertAnswerIds();
+  }
 }
 
 export default HomeService;


### PR DESCRIPTION
## 요약
- 전문의 답변 관련 라우트를 /expert-answers로 분리하고 요약 경로를 REST 스타일로 정리했습니다.
- morePosts가 항상 2개로 내려가도록 응답과 더미 데이터를 보강했습니다.
- Swagger 문서를 최신 경로로 맞췄습니다.
- 테스트용으로 answerId 전체 조회 API 추가 구현했습니다.

## 변경 사항
- /homes 경로에서 전문의 답변 관련 라우트 제거
- /expert-answers/{answerId}/summary 경로로 요약 API 정리
- morePosts 2개 고정 응답 (부족 시 null 패딩)
- 시드 데이터에서 통증 부위별 expert_answers 최소 3개 보장
- Swagger 경로 업데이트

## 비고
```
git pull origin dev
npm install
npx prisma migrate dev
npx prisma db seed
npx node/seed-extra.js
```

개발 및 수동 테스트 전에 한번식 실행해주세요.
