### PR TITLE
fix: 더미 데이터 보강 & 명세서 동기화

### DIFF
--- a/prisma/seed-extra.js
+++ b/prisma/seed-extra.js
@@ -110,32 +110,77 @@ async function main() {
   // ============================
   // 2-1) temporary_care_guides 보강
   // ============================
-  const existingGuides = await prisma.temporary_care_guides.count();
-  if (existingGuides <= painAreas.length * 3) {
-    const extraGuides = [];
-    let displayOrder = 100;
+  const existingGuides = await prisma.temporary_care_guides.findMany({
+    select: { pain_area_id: true, title: true, display_order: true },
+  });
 
-    for (const painArea of painAreas) {
-      extraGuides.push(
-        {
-          pain_area_id: painArea.pain_area_id,
-          guide_type: '스트레칭/찜질',
-          title: `${painArea.name} 간단 스트레칭`,
-          content: `${painArea.name} 주변 근육을 부드럽게 풀어주는 가벼운 스트레칭을 권장합니다.\n통증이 심하면 즉시 중단하세요.`,
-          image_url: 'https://example.com/guides/extra-stretch.png',
-          display_order: displayOrder++,
-        },
-        {
-          pain_area_id: painArea.pain_area_id,
-          guide_type: '생활 습관',
-          title: `${painArea.name} 생활 습관 점검`,
-          content: `장시간 같은 자세를 피하고, ${painArea.name}에 무리가 가는 동작을 줄여주세요.\n규칙적인 휴식이 도움이 됩니다.`,
-          image_url: 'https://example.com/guides/extra-habit.png',
-          display_order: displayOrder++,
-        }
-      );
+  const guideCounts = new Map();
+  const guideTitles = new Map();
+  const guideMaxOrder = new Map();
+
+  for (const guide of existingGuides) {
+    const key = Number(guide.pain_area_id);
+    guideCounts.set(key, (guideCounts.get(key) || 0) + 1);
+
+    const titles = guideTitles.get(key) || new Set();
+    titles.add(guide.title);
+    guideTitles.set(key, titles);
+
+    const currentMax = guideMaxOrder.get(key) || 0;
+    const nextMax = Math.max(currentMax, Number(guide.display_order || 0));
+    guideMaxOrder.set(key, nextMax);
+  }
+
+  const guideTemplates = [
+    {
+      guide_type: '스트레칭/찜질',
+      title: (name) => `${name} 간단 스트레칭`,
+      content: (name) => `${name} 주변 근육을 부드럽게 풀어주는 가벼운 스트레칭을 권장합니다.\n통증이 심하면 즉시 중단하세요.`,
+      image_url: 'https://example.com/guides/extra-stretch.png',
+    },
+    {
+      guide_type: '스트레칭/찜질',
+      title: (name) => `${name} 온찜질/냉찜질`,
+      content: () => '급성 통증에는 냉찜질을, 만성 통증에는 온찜질을 시도해보세요.',
+      image_url: 'https://example.com/guides/extra-heat.png',
+    },
+    {
+      guide_type: '생활 습관',
+      title: (name) => `${name} 생활 습관 점검`,
+      content: (name) => `장시간 같은 자세를 피하고, ${name}에 무리가 가는 동작을 줄여주세요.\n규칙적인 휴식이 도움이 됩니다.`,
+      image_url: 'https://example.com/guides/extra-habit.png',
+    },
+  ];
+
+  const extraGuides = [];
+
+  for (const painArea of painAreas) {
+    const painAreaKey = Number(painArea.pain_area_id);
+    let existingCount = guideCounts.get(painAreaKey) || 0;
+    let nextOrder = (guideMaxOrder.get(painAreaKey) || 0) + 1;
+    const titles = guideTitles.get(painAreaKey) || new Set();
+
+    for (const template of guideTemplates) {
+      if (existingCount >= 3) break;
+
+      const title = template.title(painArea.name);
+      if (titles.has(title)) continue;
+
+      extraGuides.push({
+        pain_area_id: painArea.pain_area_id,
+        guide_type: template.guide_type,
+        title,
+        content: template.content(painArea.name),
+        image_url: template.image_url,
+        display_order: nextOrder++,
+      });
+
+      titles.add(title);
+      existingCount += 1;
     }
+  }
 
+  if (extraGuides.length > 0) {
     await prisma.temporary_care_guides.createMany({ data: extraGuides });
     console.log(`temporary_care_guides 추가 ${extraGuides.length}건 삽입 완료`);
   } else {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -630,9 +630,9 @@ paths:
                               type: string
                               nullable: true
                               example: "회전근개 파열"
-                      commonGuides:
+                      temporaryGuides:
                         type: array
-                        description: "임시 치료법 가이드 (최대 3개, 부족 시 null 패딩)"
+                        description: "임시 대처 가이드 (최대 3개, 부족 시 null 패딩)"
                         items:
                           type: object
                           properties:

--- a/src/repositories/home.repository.js
+++ b/src/repositories/home.repository.js
@@ -39,7 +39,7 @@ class HomeRepository {
       return {
         banners: [],
         symptoms: [],
-        commonGuides: []
+        temporaryGuides: []
       };
     }
 
@@ -83,15 +83,15 @@ class HomeRepository {
       formattedSymptoms.push({ symptomId: null, name: null });
     }
 
-    // commonGuides: 사용자가 선택한 통증 부위의 임시 치료법 조회 (최대 3개)
-    const commonGuides = await this.client.temporary_care_guides.findMany({
+    // temporaryGuides: 사용자가 선택한 통증 부위의 임시 대처 가이드 조회 (최대 3개)
+    const temporaryGuides = await this.client.temporary_care_guides.findMany({
       where: { pain_area_id: painAreaId },
       orderBy: { display_order: 'asc' },
       take: 3,
       select: { guide_id: true, title: true, content: true, image_url: true, guide_type: true }
     });
 
-    const formattedGuides = commonGuides.map(guide => {
+    const formattedGuides = temporaryGuides.map(guide => {
       const meta = GUIDE_META_BY_TYPE[guide.guide_type] || { badges: [], duration: null };
       // 복원: seed나 DB에 이스케이프된 '\n'이 들어있을 수 있어 실제 줄바꿈으로 변환
       const description = guide.content ? String(guide.content).replace(/\\n/g, '\n') : null;
@@ -111,30 +111,12 @@ class HomeRepository {
       formattedGuides.push({ guideId: null, title: null, badges: [], description: null, imageUrl: null, type: null, duration: null });
     }
 
-    const mappedMorePosts = morePosts.map(post => ({
-      answerId: Number(post.answer_id),
-      painAreaId: Number(post.symptoms.pain_area_id),
-      symptomId: Number(post.symptom_id),
-      title: `${post.symptoms?.name} 전문의 소견`,
-      imageUrl: null
-    }));
-
-    while (mappedMorePosts.length < 2) {
-      mappedMorePosts.push({
-        answerId: null,
-        painAreaId: null,
-        symptomId: null,
-        title: null,
-        imageUrl: null
-      });
-    }
-
     return {
       painAreaId: Number(primaryPainArea.pain_area_id),
       painAreaName: primaryPainArea.name,
       banners,
       symptoms: formattedSymptoms,
-      commonGuides: formattedGuides
+      temporaryGuides: formattedGuides
     };
   }
 


### PR DESCRIPTION
## 요약
- 홈 API에서 임시 대처 가이드 키를 temporaryGuides로 변경
- 홈 응답에서 임시 대처 가이드를 항상 3개로 보장
- 더미 데이터 보강 로직으로 통증 부위별 최소 3개 유지

## 변경 사항
- /homes 응답 필드: commonGuides → temporaryGuides
- 홈 API에서 가이드 3개 고정 패딩 처리
- seed-extra 보강 로직 강화 (통증 부위별 3개 보장)
- Swagger 문서 업데이트